### PR TITLE
feat: add fish support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,20 +1,30 @@
 import { platform } from 'os'
-import { window, workspace } from 'vscode'
+import { Terminal, TerminalOptions, window, workspace } from 'vscode'
 
 const isWindows = platform() === 'win32'
 
-const COMMAND = isWindows
-  ? 'set Path=%Path%;node_modules\\.bin'
-  : 'export PATH=$PWD/node_modules/.bin:$PATH'
+function sendCommand(t: Terminal) {
+  let COMMAND = ''
+  if (isWindows)
+    COMMAND = 'set Path=%Path%;node_modules\\.bin'
+
+  else if ((t.creationOptions as TerminalOptions).shellPath?.includes('fish'))
+    COMMAND = 'fish_add_path $PWD/node_modules/.bin'
+
+  else
+    COMMAND = 'export PATH=$PWD/node_modules/.bin:$PATH'
+
+  t.sendText(COMMAND)
+}
 
 function setup() {
   window.terminals.forEach(async(t) => {
     if (await t.processId)
       return
-    t.sendText(COMMAND)
+    sendCommand(t)
   })
   window.onDidOpenTerminal((t) => {
-    t.sendText(COMMAND)
+    sendCommand(t)
   })
 }
 


### PR DESCRIPTION
I found fish problem with export PATH=$PWD/node_modules/.bin:$PATH

```
# pure fish context
echo $PATH # /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin

# config.fish
set -x PATH "/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/sbin" $PATH
echo $PATH # /opt/homebrew/bin /opt/homebrew/sbin /usr/local/sbin /usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin

# use export PATH=...:$PATH
export PATH=$PWD/node_modules/.bin:$PATH
echo $PATH # //node_modules/.bin /bin
```
export PATH=...:$PATH in fish will lose prev env

fish docs recommend use `fish_add_path` command

Referenc
https://fishshell.com/docs/current/tutorial.html#path
https://fishshell.com/docs/current/tutorial.html#exports-shell-variables
