### PR TITLE
refactor: replace the window platform command with powershell

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { window, workspace } from 'vscode'
 const isWindows = platform() === 'win32'
 
 const COMMAND = isWindows
-  ? 'set Path=%Path%;node_modules\\.bin'
+  ? '$env:PATH = "{0}\node_modules\.bin;{1}" -f (Resolve-Path .), $env:PATH'
   : 'export PATH=$PWD/node_modules/.bin:$PATH'
 
 function setup() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { window, workspace } from 'vscode'
 const isWindows = platform() === 'win32'
 
 const COMMAND = isWindows
-  ? '$env:PATH = "{0}\node_modules\.bin;{1}" -f (Resolve-Path .), $env:PATH'
+  ? '$env:PATH = "{0}\\node_modules\\.bin;{1}" -f (Resolve-Path .), $env:PATH'
   : 'export PATH=$PWD/node_modules/.bin:$PATH'
 
 function setup() {


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

As far as I know, the default terminal on the window is powershell, not a terminal like bash. At the same time, the `set Path=%Path%;node_modules\\.bin` command seems to be the grammar of cmd, and the audience of cmd is too small, so I think it will be more appropriate to replace the default command of windows with the grammar of powershell.

### Linked Issues
https://github.com/antfu/vscode-auto-npx/issues/7

### Additional context

